### PR TITLE
Enchance typing of choice-type args

### DIFF
--- a/src/lib/parser/commandArg.ts
+++ b/src/lib/parser/commandArg.ts
@@ -111,7 +111,7 @@ export const parseArgDefinition = (
       return value;
     };
   } else if (normalizedType === Type.Enum) {
-    const { byDefault, values } = argDefinition as EnumArgDefinition;
+    const { byDefault, values } = argDefinition as EnumArgDefinition<string>;
     required = byDefault === undefined;
 
     parse = (value: any) => {
@@ -184,7 +184,7 @@ const getHelpForArg = (argName: string, argDefinition: ArgDefinition) => {
     case Type.String:
       return getHelp("string", byDefault);
     case Type.Enum:
-      const { values } = argDefinition as EnumArgDefinition;
+      const { values } = argDefinition as EnumArgDefinition<string>;
       return getHelp(values.join("|"), byDefault);
     default:
       throw new Error(`internal error - unknown type: ${normalizedType}`);

--- a/src/lib/schema/args.ts
+++ b/src/lib/schema/args.ts
@@ -75,10 +75,10 @@ export const stringArgSchema: Schema = {
 
 // an enum, required if not default value is given
 // the default value must be inside the enum given in values; values must contain at least one element
-export interface EnumArgDefinition {
+export interface EnumArgDefinition<V extends string> {
   type: "enum" | "e";
-  values: string[];
-  byDefault?: string;
+  values: V[];
+  byDefault?: V;
   desc?: string;
 }
 
@@ -112,14 +112,15 @@ export const enumArgSchema: Schema = {
   additionalProperties: false
 };
 
+// @ts-ignore Ignore missing type argument. Passing it would break the feature
 export type ArgDefinition = FlagArgDefinition | StringArgDefinition | EnumArgDefinition;
 
 export type ArgInstance<T extends ArgDefinition> = T extends FlagArgDefinition
   ? boolean
   : T extends StringArgDefinition
   ? string
-  : T extends EnumArgDefinition
-  ? string
+  : T extends EnumArgDefinition<infer V>
+  ? V
   : string | boolean;
 
 export const argSchema: Schema = {

--- a/src/lib/schema/commands.ts
+++ b/src/lib/schema/commands.ts
@@ -3,7 +3,7 @@
 import { Schema } from "jsonschema";
 import { config } from "../config";
 import { alphanumericExtendedPattern } from "./";
-import { ArgDefinitions, ArgsInstance, argsSchema } from "./args";
+import { ArgDefinitions, ArgsInstance, argsSchema, ArgDefinition } from "./args";
 import { ExecCommand, ExecFunction } from "./runtime";
 
 export type CommandRunFn<TArgDefs extends ArgDefinitions> = (
@@ -71,7 +71,8 @@ export class CommandBuilder<TArgDefs extends ArgDefinitions> {
     Object.keys(argDescs).forEach((argName: keyof TArgDefs) => {
       const desc = argDescs[argName];
 
-      const argObj = (this._command.args![argName] = this._command.args![argName] || {});
+      const argObj = (this._command.args![argName] =
+        this._command.args![argName] || ({} as ArgDefinition));
       Object.assign(argObj, { desc });
     });
 

--- a/src/lib/simpleArgs.ts
+++ b/src/lib/simpleArgs.ts
@@ -13,7 +13,10 @@ export function str(byDefault?: string): StringArgDefinition {
   };
 }
 
-export function choice(values: string[], byDefault?: string): EnumArgDefinition {
+export function choice<V extends string = string>(
+  values: V[],
+  byDefault?: V
+): EnumArgDefinition<V> {
   return {
     type: "enum",
     values,


### PR DESCRIPTION
This PR enhances the typing to infer the possible choice values from the `choice(...)` command and to display them in the args.

An example of what has changed:
```ts
import { choice, cmd } from './lib/index';

cmd('test')
	.desc('abc')
	.args({
		arg: choice(['a', 'b', 'c'], 'a')
	})
	.run(async (exec, args) => {
		args.arg // "a" | "b" | "c", used to be string
	});
```

I tend to make this change in my own projects when I use makfy and I figured others might want to use it as well. This allows for easier `switch` statements that actually know all possible values instead of just `string`.

The gist of the change is: make `choice` infer the values and pass those back to `args`. The rest is just a bunch of fixes for type errors that show up since `EnumArgDefinition` now wants a generic type argument.